### PR TITLE
Add log request to warn user when interactions component is auto-added

### DIFF
--- a/Assets/Inworld.AI/Scripts/Runtime/Entities/InworldCharacter.cs
+++ b/Assets/Inworld.AI/Scripts/Runtime/Entities/InworldCharacter.cs
@@ -160,6 +160,7 @@ namespace Inworld
         {
             if (!m_Interaction || !m_Interaction.enabled)
             {
+               InworldAI.Log($"not set audio interaction component in {gameObject}");
                 m_Interaction = gameObject.AddComponent<Interactions>();
                 m_Interaction.enabled = true;
             }


### PR DESCRIPTION
Added not set audio interaction component in {gameObject} log.

Reason for making a pull request
1. The Interactions component was created automatically, but I didn't recognize it.
2. Due to the component, overlapping events with custom components occurred, resulting in duplicate firing issues.
3. I spent a lot of time looking for the issue.
4. The log tracking is not smooth because the occurrence point tracking of OnPacketEvents assigned in Interactions is not clear.

Benefit
1. Users can prevent or predict unintended issues by warning them.

result
1. Notifications are given when the Interactions component is automatically created, making it easier to understand logs.